### PR TITLE
add test for process_model

### DIFF
--- a/fortran-tf-lib/tools/tests/test_process_model.py
+++ b/fortran-tf-lib/tools/tests/test_process_model.py
@@ -1,0 +1,22 @@
+import pytest
+import subprocess
+import os
+
+def test_f90_created():
+	"""
+	test if process_model generates the FORTRAN file
+	""" 
+	subprocess.run(["process_model", "../my_model/", "-o", "testf.f90"], check=True)
+	assert os.path.isfile("testf.f90")
+	os.remove("testf.f90")
+
+def test_f90_compile():
+	""" 
+	test if the FORTRAN file generated from process_model compiles
+	"""
+	subprocess.run(["process_model", "../my_model/", "-o", "testf.f90"])
+	ret = subprocess.run(["gfortran", "-c", "-I", "../src/", "testf.f90"], check=True)
+	assert ret.returncode == 0
+	os.remove("testf.f90")
+	os.remove("testf.o")
+	os.remove("ml_model.mod")


### PR DESCRIPTION
This PR is in the process of addressing #4; it adds two test for `process_model`:
- [x] test if `process_model` generates a FORTRAN file;
- [x] test if the generated FORTRAN file can compile.
